### PR TITLE
Fix crash shared lock

### DIFF
--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -223,7 +223,7 @@ void ThreadIRCSeed(void* parg)
 
 void ThreadIRCSeed2(void* parg)
 {
-    LOCK(cs_net);
+//    LOCK(cs_net);
     {
     // Don't connect to IRC if we won't use IPv4 connections.
     if (IsLimited(NET_IPV4))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1431,7 +1431,7 @@ CBigNum inline GetProofOfStakeLimit(int nHeight, unsigned int nTime)
             break;
 
         case MAX_BLOCK_SIGOPS:
-            nMaxSize = max(nMaxSize, (::uint64_t)DEFAULT_MAX_BLOCK_SIGOPS);
+            nMaxSize = max(nMaxSize, (::uint64_t)MAX_GENESIS_BLOCK_SIZE) / 50;
             break;
 
         case MAX_BLOCK_SIZE:

--- a/src/main.h
+++ b/src/main.h
@@ -61,7 +61,6 @@ extern int
 
 static const unsigned int MAX_GENESIS_BLOCK_SIZE = 1000000;
 static const unsigned int MAX_ORPHAN_TRANSACTIONS = 10000;
-static const unsigned int DEFAULT_MAX_BLOCK_SIGOPS = 20000;
 static const unsigned int MAX_INV_SZ = 50000;
 
 static const ::int64_t MIN_TX_FEE = CENT;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2694,7 +2694,7 @@ void ThreadMessageHandler2(void* parg)
 
 bool BindListenPort(const CService &addrBind, string& strError)
 {
-    LOCK(cs_net);
+//    LOCK(cs_net);
     {
     strError = "";
     u_long

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -359,7 +359,7 @@ bool static Socks5(std::string strDest, int port, SOCKET& hSocket)
 
 bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRet, int nTimeout)
 {
-    LOCK(cs_net);
+//    LOCK(cs_net);
     {
     hSocketRet = INVALID_SOCKET;
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1227,8 +1227,10 @@ public:
         ::int64_t nMaxCacheSize = GetArg("-maxsigcachesize", 50000);
         if (nMaxCacheSize <= 0) return;
 
-        boost::shared_lock<boost::shared_mutex> lock(cs_sigcache);
+        // We must use unique_lock, instead of shared_lock for writer
+//        boost::shared_lock<boost::shared_mutex> lock(cs_sigcache);
         //LOCK(cs_sigcache);
+        boost::unique_lock< boost::shared_mutex > lock(cs_sigcache);
 
         while (static_cast< ::int64_t>(setValid.size()) > nMaxCacheSize)
         {
@@ -1262,7 +1264,9 @@ public:
         ::int64_t nMaxCacheSize = GetArg("-maxsigcachesize", 50000);
         if (nMaxCacheSize <= 0) return;
 
-        boost::shared_lock<boost::shared_mutex> lock(cs_sigcache);
+        // We must use unique_lock, instead of shared_lock for writer
+//        boost::shared_lock<boost::shared_mutex> lock(cs_sigcache);
+        boost::unique_lock< boost::shared_mutex > lock(cs_sigcache);
 
         while (static_cast< ::int64_t>(setValid.size()) > nMaxCacheSize)
         {

--- a/src/stun.cpp
+++ b/src/stun.cpp
@@ -279,7 +279,7 @@ static int StunRequest2(int sock, struct sockaddr_in *server, struct sockaddr_in
 /*---------------------------------------------------------------------*/
 static int StunRequest(const char *host, uint16_t port, struct sockaddr_in *mapped) 
 {
-    LOCK(cs_net);
+//    LOCK(cs_net);
     {
 
     struct hostent *hostinfo = gethostbyname(host);


### PR DESCRIPTION
* fix: must use unique_lock, instead of shared_lock for writer
* fix: revert some change : fix_threadOpenAddedConnection
* Modify default max block sigops